### PR TITLE
add default method to fallback to calling getParent on run

### DIFF
--- a/src/main/java/jenkins/scm/api/SCMFileSystem.java
+++ b/src/main/java/jenkins/scm/api/SCMFileSystem.java
@@ -169,7 +169,7 @@ public abstract class SCMFileSystem implements Closeable {
      * @throws InterruptedException if the attempt to create a {@link SCMFileSystem} was interrupted.
      */
     @CheckForNull
-    public static SCMFileSystem of(@NonNull Run build, @NonNull SCM scm) throws IOException, InterruptedException {
+    public static SCMFileSystem of(@NonNull Run<?, ?> build, @NonNull SCM scm) throws IOException, InterruptedException {
         return of(build, scm, null);
     }
 

--- a/src/main/java/jenkins/scm/api/SCMFileSystem.java
+++ b/src/main/java/jenkins/scm/api/SCMFileSystem.java
@@ -568,8 +568,10 @@ public abstract class SCMFileSystem implements Closeable {
          * @throws InterruptedException if the attempt to create a {@link SCMFileSystem} was interrupted.
          */
         @CheckForNull
-        public abstract SCMFileSystem build(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
-                throws IOException, InterruptedException;
+        public SCMFileSystem build(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+                throws IOException, InterruptedException {
+            return build(build.getParent(), scm, rev);
+        }
 
         /**
          * Given a {@link SCM} this should try to build a corresponding {@link SCMFileSystem} instance that

--- a/src/main/java/jenkins/scm/api/SCMFileSystem.java
+++ b/src/main/java/jenkins/scm/api/SCMFileSystem.java
@@ -186,7 +186,7 @@ public abstract class SCMFileSystem implements Closeable {
      * @throws InterruptedException if the attempt to create a {@link SCMFileSystem} was interrupted.
      */
     @CheckForNull
-    public static SCMFileSystem of(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+    public static SCMFileSystem of(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
             throws IOException, InterruptedException {
         Objects.requireNonNull(scm);
         SCMFileSystem fallBack = null;

--- a/src/test/java/jenkins/scm/impl/SCMFileSystemTest.java
+++ b/src/test/java/jenkins/scm/impl/SCMFileSystemTest.java
@@ -120,7 +120,7 @@ public class SCMFileSystemTest {
 
         @Override
         @CheckForNull
-        public SCMFileSystem build(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+        public SCMFileSystem build(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
                 throws IOException, InterruptedException {
             return null;
         }
@@ -158,7 +158,7 @@ public class SCMFileSystemTest {
 
         @Override
         @CheckForNull
-        public SCMFileSystem build(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
+        public SCMFileSystem build(@NonNull Run<?, ?> build, @NonNull SCM scm, @CheckForNull SCMRevision rev)
                 throws IOException, InterruptedException {
             return null;
         }


### PR DESCRIPTION
for any SCMFileSystem that has yet to implement Run method